### PR TITLE
Add VS Code overlay terminal extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # overlay-terminal
-Vs Code plugin to open terminal in temporary window
+
+VS Code plugin to open a terminal in a temporary window and close on exit.
+
+## Build and install
+
+```sh
+npm run deploy
+```
+
+Alternatively, run the steps manually:
+
+```sh
+npm i -D @types/node
+npm i
+npm run build
+code --install-extension ./overlay-terminal.vsix
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "overlay-terminals-return",
+  "displayName": "Overlay Terminal: New Window + Close On Exit",
+  "version": "0.2.0",
+  "publisher": "local",
+  "engines": { "vscode": "^1.82.0" },
+  "main": "dist/extension.js",
+  "repository": "https://github.com/F286/dotfiles",
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:overlayTerminals.openProfile",
+    "onCommand:overlayTerminals.pickProfile"
+  ],
+  "contributes": {
+    "commands": [
+      { "command": "overlayTerminals.openProfile", "title": "Overlay Terminal: Open Profile" },
+      { "command": "overlayTerminals.pickProfile", "title": "Overlay Terminal: Pick Profile" }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "build": "npm run compile",
+    "package": "npx @vscode/vsce package -o overlay-terminal.vsix",
+    "install": "code --install-extension overlay-terminal.vsix --force",
+    "deploy": "npm run build && npm run package && npm run install"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/vscode": "^1.82.0",
+    "typescript": "^5.4.0",
+    "@vscode/vsce": "^3.0.0"
+  }
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,104 @@
+import * as vscode from 'vscode';
+
+const OVERLAY_PREFIX = '[overlay] ';
+
+export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('overlayTerminals.openProfile', async (args?: {
+      profileName?: string;
+    }) => {
+      const profileName = args?.profileName ?? (await pickConfiguredProfileName());
+      if (!profileName) return;
+
+      const overlayName = OVERLAY_PREFIX + profileName + ' #' + randomId();
+
+      // Get the configuration for the selected profile
+      const platform = process.platform === 'darwin' ? 'osx' : process.platform === 'win32' ? 'windows' : 'linux';
+      const cfg = vscode.workspace.getConfiguration('terminal.integrated');
+      const profiles = cfg.get<Record<string, { path: string, args?: string[] } | string>>(`profiles.${platform}`) ?? {};
+      const profileConfig = profiles[profileName];
+
+      if (!profileConfig) {
+        vscode.window.showErrorMessage(`Terminal profile "${profileName}" not found.`);
+        return;
+      }
+
+      // Create terminal options from the profile config
+      const location: vscode.TerminalEditorLocationOptions = {
+        viewColumn: vscode.ViewColumn.Active
+      };
+
+      const options: vscode.TerminalOptions = { name: overlayName, location };
+      if (typeof profileConfig === 'string') {
+        options.shellPath = profileConfig;
+      } else {
+        options.shellPath = profileConfig.path;
+        options.shellArgs = profileConfig.args;
+      }
+
+      const terminal = vscode.window.createTerminal(options);
+      terminal.show(true);
+
+      await vscode.commands.executeCommand('workbench.action.terminal.moveIntoNewWindow');
+    }),
+
+    vscode.commands.registerCommand('overlayTerminals.pickProfile', async () => {
+      const name = await pickConfiguredProfileName();
+      if (!name) return;
+      await vscode.commands.executeCommand('overlayTerminals.openProfile', { profileName: name });
+    })
+  );
+
+context.subscriptions.push(
+  vscode.window.onDidChangeActiveTextEditor(async (editor) => {
+    // Only act if focus moved to a real text editor
+    if (editor) {
+      // 1. Give focus a moment to settle on the text editor
+      await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
+      await delay(50); // A small delay is often crucial
+
+      // 2. Now send the escape command
+      await cmd('extension.vim_escape');
+      
+      // For maximum reliability, you can even send it twice
+      await delay(50);
+      await cmd('extension.vim_escape');
+    }
+  })
+);
+}
+
+export function deactivate() {}
+
+/* ------------------ Helpers ------------------ */
+
+async function pickConfiguredProfileName(): Promise<string | undefined> {
+  const platform = process.platform === 'darwin' ? 'osx' : process.platform === 'win32' ? 'windows' : 'linux';
+  const cfg = vscode.workspace.getConfiguration('terminal.integrated');
+  const profiles = cfg.get<Record<string, unknown>>(`profiles.${platform}`) ?? {};
+  const items = Object.keys(profiles).sort().map(label => ({ label }));
+  if (!items.length) {
+    await vscode.commands.executeCommand('workbench.action.terminal.newWithProfile');
+    return undefined;
+  }
+  const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select a terminal profile' });
+  return pick?.label;
+}
+
+function randomId(): string {
+  return Math.random().toString(36).slice(2, 6);
+}
+
+async function cmd(id: string, args?: unknown): Promise<boolean> {
+  try {
+    await vscode.commands.executeCommand(id, args as never);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function delay(ms: number) {
+  return new Promise<void>(r => setTimeout(r, ms));
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "types": ["node", "vscode"],
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+


### PR DESCRIPTION
## Summary
- add overlay-terminal VS Code extension source
- document build instructions for the extension
- remove license file
- drop committed VSIX package artifact

## Testing
- `npm install --no-fund --no-audit --ignore-scripts --package-lock=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae5873f33c83248ee22d538f872682