### PR TITLE
Add build workflow and clarify plugin README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Build & Release VSIX
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts || npm install --ignore-scripts
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Package VSIX
+        run: npm run package -- --no-git-tag-version
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: overlay-terminal-vsix
+          path: overlay-terminal.vsix
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: overlay-terminal-vsix
+          path: .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: overlay-terminal.vsix
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,18 +1,50 @@
-# overlay-terminal
+# Overlay Terminal for VS Code
 
-VS Code plugin to open a terminal in a temporary window and close on exit.
+[![Latest release](https://img.shields.io/github/v/release/F286/overlay-terminal?sort=semver)](https://github.com/F286/overlay-terminal/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/F286/overlay-terminal/latest/total)](https://github.com/F286/overlay-terminal/releases/latest)
+[![CI](https://github.com/F286/overlay-terminal/actions/workflows/release.yml/badge.svg)](https://github.com/F286/overlay-terminal/actions/workflows/release.yml)
 
-## Build and install
+A tiny VS Code extension that opens a terminal **in a new window** using any of your configured terminal profiles. When the shell exits the window closes and focus returns to the editor (sending `Esc` for VSCodeVim users).
 
-```sh
-npm run deploy
-```
+> Requires VS Code **1.82+**
 
-Alternatively, run the steps manually:
+## Install
 
-```sh
-npm i -D @types/node
-npm i
+### From the latest release
+1. Download the `.vsix` from the [latest release](https://github.com/F286/overlay-terminal/releases/latest).
+2. Install it:
+   ```bash
+   code --install-extension ./overlay-terminal.vsix
+   ```
+
+### From source
+```bash
+npm install --ignore-scripts
 npm run build
-code --install-extension ./overlay-terminal.vsix
+npm run package
+# overlay-terminal.vsix will appear in the repo root
 ```
+
+## Usage
+
+* Command Palette: `Overlay Terminal: Pick Profile`.
+* Open a specific profile with a keybinding:
+  ```jsonc
+  {
+    "key": "ctrl+`",
+    "command": "overlayTerminals.openProfile",
+    "args": { "profileName": "zsh" }
+  }
+  ```
+
+The extension uses your OS specific `terminal.integrated.profiles.*` setting and moves the terminal into a separate window with `workbench.action.terminal.moveIntoNewWindow`.
+
+## CI / Releases
+
+* Every push to `main` builds the extension and uploads the packaged `.vsix` as a workflow artifact.
+* Pushing a tag like `v0.2.0` also creates a GitHub release with the `.vsix` attached.
+
+## Commands
+
+* `overlayTerminals.openProfile` – Overlay Terminal: Open Profile
+* `overlayTerminals.pickProfile` – Overlay Terminal: Pick Profile


### PR DESCRIPTION
## Summary
- build VSIX with GitHub Actions and attach it to tagged releases
- document extension usage and link badges to latest release

## Testing
- `npm install --ignore-scripts --loglevel=error`
- `npm run build`
- `npm run package`

------
https://chatgpt.com/codex/tasks/task_e_68aeefab41a48324964e01e80bf5af1b