### PR TITLE
docs: add direct VSIX download link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Build extension
         run: npm run build
 
+      - name: Sync package.json version to tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VER="${GITHUB_REF#refs/tags/}"; VER="${VER#v}"
+          npm version "$VER" --no-git-tag-version
+
       - name: Package VSIX
         run: npm run package -- --no-git-tag-version
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A tiny VS Code extension that opens a terminal **in a new window** using any of 
 ## Install
 
 ### From the latest release
-1. Download the `.vsix` from the [latest release](https://github.com/F286/overlay-terminal/releases/latest).
+1. [⬇️ Download the latest `.vsix`](https://github.com/F286/overlay-terminal/releases/latest/download/overlay-terminal.vsix).
 2. Install it:
    ```bash
    code --install-extension ./overlay-terminal.vsix


### PR DESCRIPTION
## Summary
- point README to the latest VSIX file for quick installs
- keep package.json version in sync with release tags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af77d2e2888324b854d29f89d977da